### PR TITLE
feat: use tsup for bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 /*.js
 /*.ts
 /*.d.ts.map
+/*lock.yaml
+.idea
+dist

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "index.ts"
   ],
   "type": "module",
-  "main": "index.js",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@noble/secp256k1": "~1.7.0",
     "@noble/hashes": "~1.1.1",
@@ -23,7 +23,8 @@
     "micro-should": "0.2.0",
     "prettier": "2.6.2",
     "typescript": "4.7.3",
-    "micro-packed-debugger": "0.3.1"
+    "micro-packed-debugger": "0.3.1",
+    "tsup": "6.5.0"
   },
   "author": "Paul Miller (https://paulmillr.com)",
   "license": "MIT",
@@ -33,7 +34,7 @@
     "url": "git+https://github.com/paulmillr/micro-btc-signer.git"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsup",
     "lint": "prettier --check index.ts",
     "test": "node test/index.test.js && node test/psbt-test/bip174-psbt-extended.test.js",
     "test:extended": "node --experimental-loader ./test/bitcoinjs-test/esm-loader.js ./test/bitcoinjs-test/index.test.js"


### PR DESCRIPTION
This PR is just an example of how we can use `tsup` to take care of bundling. I personally love `tsup` and many projects make use of it. -> https://tsup.egoist.dev/

bundling takes less than 1 second on my machine:

```
CLI Building entry: index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v6.5.0
CLI Using tsup config: ./micro-btc-signer/tsup.config.ts
CLI Target: node16
CLI Cleaning output folder
CJS Build start
ESM Build start
DTS Build start
CJS dist/index.cjs 50.92 KB
CJS ⚡️ Build success in 210ms
ESM dist/index.js 47.46 KB
ESM ⚡️ Build success in 210ms
DTS ⚡️ Build success in 662ms
DTS dist/index.d.ts 60.88 KB

Process finished with exit code 0
```