### PR TITLE
Use stricter return type for `getAddress` utility

### DIFF
--- a/src/payment.ts
+++ b/src/payment.ts
@@ -767,7 +767,7 @@ export function getAddress(
   type: 'pkh' | 'wpkh' | 'tr',
   privKey: Bytes,
   network: BTC_NETWORK = NETWORK
-): string | undefined {
+): string {
   if (type === 'tr') {
     return p2tr(u.pubSchnorr(privKey), undefined, network).address;
   }


### PR DESCRIPTION
All the code paths in the `getAddress` utility return a `string`, so we can narrow the return type from `string | undefined` to just `string`.

This will avoid the need for extraneous checks in downstream code like the following:

```typescript
const address = getAddress("wpkh", privateKey, network);

if (address === undefined) {
  throw new Error("Address was undefined. This should never happen.");
}
```