### PR TITLE
Change should greater than dust when alwaysChange

### DIFF
--- a/src/utxo.ts
+++ b/src/utxo.ts
@@ -408,7 +408,7 @@ export class _Estimator {
       inputsAmount += amount;
       res.add(idx);
       // inputsAmount is enough to cover cost of tx
-      if (!all && targetAmount + fee <= inputsAmount && num >= this.requiredIndices.length)
+      if (!all && targetAmount + fee + (this.opts.alwaysChange ? this.dust : 0n) <= inputsAmount && num >= this.requiredIndices.length)
         return { indices: Array.from(res), fee, weight: totalWeight, total: inputsAmount };
     }
     for (const idx of indices) {
@@ -431,7 +431,7 @@ export class _Estimator {
       inputsAmount += amount;
       res.add(idx);
       // inputsAmount is enough to cover cost of tx
-      if (!all && targetAmount + fee <= inputsAmount)
+      if (!all && targetAmount + fee + (this.opts.alwaysChange ? this.dust : 0n) <= inputsAmount)
         return { indices: Array.from(res), fee, weight: totalWeight, total: inputsAmount };
     }
     if (all) {


### PR DESCRIPTION
Change smaller than dust is meaningless. When `alwaysChange: true`, the change should be greater than dust.
```typescript
import * as btc from "@scure/btc-signer";
import { hex } from "@scure/base";

const P2PKH_SCRIPT = hex.decode(
    "76a914168b992bcfc44050310b3a94bd0771136d0b28d188ac"
);

async function main() {
    const requiredInputs = [
        {
            txid: new Uint8Array(32).fill(0xaa),
            index: 0,
            witnessUtxo: {
                script: P2PKH_SCRIPT,
                amount: 2835324n,
            },
        },
        {
            txid: new Uint8Array(32).fill(0xbb),
            index: 0,
            witnessUtxo: {
                script: P2PKH_SCRIPT,
                amount: 205887n,
            },
        },
        {
            txid: new Uint8Array(32).fill(0xcc),
            index: 0,
            witnessUtxo: {
                script: P2PKH_SCRIPT,
                amount: 5000n,
            },
        }
    ];


    const outputs = [
        {
            address: "134D6gYy8DsR5m4416BnmgASuMBqKvogQh",
            amount: 760286n,
        },
        {
            address: "134D6gYy8DsR5m4416BnmgASuMBqKvogQh",
            amount: 760286n,
        },
        {
            address: "134D6gYy8DsR5m4416BnmgASuMBqKvogQh",
            amount: 760286n,
        },
        {
            address: "134D6gYy8DsR5m4416BnmgASuMBqKvogQh",
            amount: 760286n,
        },
    ];

    const selection = selectUTXO(requiredInputs, outputs, "default", {
        alwaysChange: true,
        feePerByte: 0n,
        allowSameUtxo: false,
        allowLegacyWitnessUtxo: true,
        disableScriptCheck: true,
        createTx: false, 
        changeAddress: "134D6gYy8DsR5m4416BnmgASuMBqKvogQh",
    });

    if (!selection) {
        console.log("No selection");
        return;
    }

    selection.inputs.forEach((inp, idx) => {
        const { txid, index, witnessUtxo } = inp;
        console.log(
            `  #${idx}: txid=${hex.encode(txid!)} amount=${witnessUtxo?.amount
            }`
        );
    });

    selection.outputs.forEach((inp, idx) => {
        const { address, amount } = inp;
        console.log(
            `  #${idx}: address=${address} amount=${amount
            }`
        );
    });
}

main().catch((err) => console.error(err));
```
The example above will change 67 sat, but it would be better to change 5067 sat

