### PR TITLE
test(musig2): tighten BIP327 error assertions

### DIFF
--- a/test/bip327-musig2.test.ts
+++ b/test/bip327-musig2.test.ts
@@ -23,7 +23,8 @@ const assertError = (error, cb) => {
   try {
     cb();
   } catch (e) {
-    if (error.signer)
+    if (e instanceof ReferenceError) throw e;
+    if (error.type === 'invalid_contribution' && error.signer !== null)
       deepStrictEqual(e, new musig2.InvalidContributionErr(error.signer, error.contrib));
     return;
   }
@@ -400,7 +401,7 @@ describe('BIP327', () => {
       assertError(t.error, () => {
         // TODO: uses already aggregated nonce here
         const session = new musig2.Session(aggNonce, publicKeys, msg);
-        session.sign(secnonce, sk, sessionCtx);
+        session.sign(secnonce, sk);
       });
     }
     for (const t of signVerifyVectors.verify_fail_test_cases) {


### PR DESCRIPTION
This tightens the MuSig2 BIP327 vector test harness.

Previously, assertError used a truthiness check on error.signer, which skipped exact InvalidContributionErr checks for vectors with signer 0. One sign-error case also passed an undefined sessionCtx argument, allowing a ReferenceError to occur before Session.sign exercised the intended vector path.

This change rethrows accidental ReferenceErrors and checks invalid_contribution vectors whenever signer !== null, including signer 0.

Tests:
- node --no-warnings test/bip327-musig2.test.ts
- npm test