### PR TITLE
Make preimageLegacy public

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1080,7 +1080,7 @@ export class Transaction {
   // Based on https://github.com/bitcoin/bitcoin/blob/5871b5b5ab57a0caf9b7514eb162c491c83281d5/test/functional/test_framework/script.py#L624
   // There is optimization opportunity to re-use hashes for multiple inputs for witness v0/v1,
   // but we are trying to be less complicated for audit purpose for now.
-  private preimageLegacy(idx: number, prevOutScript: Bytes, hashType: number) {
+  preimageLegacy(idx: number, prevOutScript: Bytes, hashType: number) {
     const { isAny, isNone, isSingle } = unpackSighash(hashType);
     if (idx < 0 || !Number.isSafeInteger(idx)) throw new Error(`Invalid input idx=${idx}`);
     if ((isSingle && idx >= this.outputs.length) || idx >= this.inputs.length)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -265,7 +265,7 @@ should('legacy sighash preserves non-minimal push bytes when removing CODESEPARA
     P.I32LE.encode(btc.SigHash.ALL)
   );
   deepStrictEqual(
-    hex.encode((tx as any).preimageLegacy(0, original, btc.SigHash.ALL)),
+    hex.encode(tx.preimageLegacy(0, original, btc.SigHash.ALL)),
     hex.encode(expected)
   );
 });


### PR DESCRIPTION
Continuation of #61. Mirrors the public access already granted to `preimageWitnessV0` and `preimageWitnessV1`. Provides callers signing P2PKH inputs with public access to `preimageLegacy` eliminating need for workarounds (fork or cast). Closes #142.